### PR TITLE
グラフのモックアップ作成と登録編集画面の修正

### DIFF
--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -4908,8 +4908,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -4930,14 +4929,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -4952,20 +4949,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5082,8 +5076,7 @@
         "inherits": {
           "version": "2.0.4",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5095,7 +5088,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5110,7 +5102,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5118,14 +5109,12 @@
         "minimist": {
           "version": "1.2.5",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.9.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5144,7 +5133,6 @@
           "version": "0.5.3",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "^1.2.5"
           }
@@ -5206,8 +5194,7 @@
         "npm-normalize-package-bin": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "npm-packlist": {
           "version": "1.4.8",
@@ -5235,8 +5222,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5248,7 +5234,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5326,8 +5311,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5363,7 +5347,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5383,7 +5366,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5427,14 +5409,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -10496,7 +10476,7 @@
     },
     "sass": {
       "version": "1.26.5",
-      "resolved": "https://registry.npm.taobao.org/sass/download/sass-1.26.5.tgz",
+      "resolved": "https://registry.npm.taobao.org/sass/download/sass-1.26.5.tgz?cache=0&sync_timestamp=1587697502481&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsass%2Fdownload%2Fsass-1.26.5.tgz",
       "integrity": "sha1-LXrs+7q/ophWfI8GYVtuJNLWgJk=",
       "dev": true,
       "requires": {

--- a/vue/src/chart/Chart.vue
+++ b/vue/src/chart/Chart.vue
@@ -9,12 +9,12 @@ export default {
     return {
       data: {
         // ここに年齢が入るからlabelsの中は空にする
-        labels: ['A', 'B', 'C', 'D', 'E', 'F'],
+        labels: [],
         datasets: [
           {
             // ここにスコアが入るからlabelsの中は空にする
-            data: [0, 70, 40, -80, 10, 100],
-            borderColor: 'rgba(255, 99, 132, 0.2)',
+            data: [],
+            borderColor: '#26A69A',
             fill: false,
             lineTension: 0.4
           }
@@ -22,8 +22,10 @@ export default {
       },
       options: {
         tooltips: {
-          callbacks: {
-          }
+          // ツールチップのデフォルト設定の無効化
+          enabled: false,
+          // カスタム
+          custom: []
         },
         // 凡例消す
         legend: false,
@@ -58,7 +60,97 @@ export default {
     }
   },
   mounted () {
+    this.setLabels()
+    this.setData()
+    this.setComments()
     this.renderChart(this.data, this.options)
+  },
+  methods: {
+    setLabels () {
+      //  agesに配列を渡す
+      const ages = []
+      // stageからcontents配列を呼び込みagesにcontentsのインデックス順にageを渡す
+      this.$store.state.chart.contents.map((content) => {
+        ages.push(content.age)
+      })
+      // labelsの中に代入する
+      this.data.labels = ages
+    },
+    setData () {
+      const scores = []
+      this.$store.state.chart.contents.map((content) => {
+        scores.push(content.score)
+      })
+      this.data.datasets[0].data = scores
+    },
+    setComments () {
+      const comments = []
+      this.$store.state.chart.contents.map((content) => {
+        // commentsにageとcommentのオブジェクトを入れる
+        comments.push({ age: content.age, comment: content.comment })
+      })
+      this.options.tooltips.custom = function (tooltipModel) {
+        // ツールチップ要素の指定
+        var tooltipEl = document.getElementById('chartjs-tooltip')
+        // 最初のレンダリング時に要素を作成する
+        if (!tooltipEl) {
+          tooltipEl = document.createElement('div')
+          tooltipEl.id = 'chartjs-tooltip'
+          tooltipEl.innerHTML = '<table></table>'
+          // 対象のノードにtooltipEl要素を追加
+          document.body.appendChild(tooltipEl)
+        }
+        // ツールチップがなければ非表示
+        if (tooltipModel.opacity === 0) {
+          tooltipEl.style.opacity = 0
+          return
+        }
+        function getBody (bodyItem) {
+          return bodyItem.lines
+        }
+        // テキストを設定する
+        if (tooltipModel.body) {
+          var titleLines = tooltipModel.title
+          var bodyLines = tooltipModel.body.map(getBody)
+          var innerHtml = '<thead>'
+          // x軸の値を返してくれる
+          titleLines.forEach(function (age) {
+            // 配列であるcommnetsのなかのageが、function内でループしているageと=になる時のcommentを見てくる
+            var comment = comments.find(comment => comment.age === age).comment
+            innerHtml += '<tr><th>' + age + '歳' + '</th></tr>'
+            // innerHtml += '</thead><tbody>'
+            bodyLines.forEach(function (body, i) {
+              var colors = tooltipModel.labelColors[i]
+              var style = 'background:' + colors.backgroundColor
+              style += '; border-color:' + colors.borderColor
+              style += '; border-width: 2px'
+              var span = '<span style="' + style + '"></span>'
+              // '<tr><td>' は多分改行
+              if (comment) {
+                innerHtml += '<tr><td>' + span + '満足度：' + body + ' ポイント' + '</td></tr>' + '内容：' + comment
+              } else {
+                innerHtml += '<tr><td>' + span + '満足度：' + body + ' ポイント' + '</td></tr>'
+              }
+            })
+          })
+          innerHtml += '</tbody>'
+          var tableRoot = tooltipEl.querySelector('table')
+          tableRoot.innerHTML = innerHtml
+        }
+        // 要素の寸法と、そのビューポートに対する位置
+        var position = this._chart.canvas.getBoundingClientRect()
+        // 表示、配置、およびフォントスタイルの設定
+        tooltipEl.style.opacity = 1
+        tooltipEl.style.position = 'absolute'
+        tooltipEl.style.left = position.left + window.pageXOffset + tooltipModel.caretX + 'px'
+        tooltipEl.style.top = position.top + window.pageYOffset + tooltipModel.caretY + 'px'
+        tooltipEl.style.fontFamily = tooltipModel._bodyFontFamily
+        tooltipEl.style.fontSize = tooltipModel.bodyFontSize + 'px'
+        tooltipEl.style.fontStyle = tooltipModel._bodyFontStyle
+        tooltipEl.style.padding = tooltipModel.yPadding + 'px ' + tooltipModel.xPadding + 'px'
+        tooltipEl.style.pointerEvents = 'none'
+      }
+    }
   }
 }
 </script>

--- a/vue/src/main.js
+++ b/vue/src/main.js
@@ -3,6 +3,7 @@ import App from './App.vue'
 import router from './router'
 import store from './store'
 import vuetify from './plugins/vuetify'
+
 // import "vuetify/dist/vuetify.min.css";
 
 Vue.config.productionTip = false

--- a/vue/src/store/index.js
+++ b/vue/src/store/index.js
@@ -1,35 +1,42 @@
 import Vue from 'vue'
 import Vuex from 'vuex'
-import axios from 'axios'
+import chart from './modules/chart.js'
+// import axios from 'axios'
 
 Vue.use(Vuex)
-
-const config = {
-  headers: {
-    'Access-Control-Allow-Origin': '*'
-  }
-}
-
 export default new Vuex.Store({
-  state: {
-    account: {
-      // TODO: delete because of test
-      login: 'ng'
-    }
-  },
-  mutations: {
-    // TODO: delete because of test
-    setLogin (state, payload) {
-      state.login = payload.login
-    }
-  },
-  actions: {
-    // TODO: delete because of test
-    fetchLogin ({ commit }) {
-      const url = '/api/auth/login'
-      axios.get(url, config).then((res) => {
-        commit('setLogin', res.data)
-      })
-    }
+  modules: {
+    chart
   }
 })
+// const config = {
+//   headers: {
+//     'Access-Control-Allow-Origin': '*'
+//   }
+// }
+// export default new Vuex.Store({
+//   modules: {
+//    chart
+//   },
+//   state: {
+//     account: {
+//       // TODO: delete because of test
+//       login: 'ng'
+//     }
+//   },
+//   mutations: {
+//     // TODO: delete because of test
+//     setLogin (state, payload) {
+//       state.login = payload.login
+//     }
+//   },
+//   actions: {
+//     // TODO: delete because of test
+//     fetchLogin ({ commit }) {
+//       const url = '/api/auth/login'
+//       axios.get(url, config).then((res) => {
+//         commit('setLogin', res.data)
+//       })
+//     }
+//   }
+// })

--- a/vue/src/store/modules/chart.js
+++ b/vue/src/store/modules/chart.js
@@ -1,0 +1,19 @@
+// import Vue from 'vue'
+// import Vuex from 'vuex'
+// Vue.use(Vuex)
+export default {
+  state: {
+    contents: [],
+    load: false
+  },
+  mutations: {
+    setContents (state, contents) {
+      state.contents = contents
+    }
+  },
+  actions: {
+    setContents ({ commit }, contents) {
+      commit('setContents', contents)
+    }
+  }
+}

--- a/vue/src/views/New.vue
+++ b/vue/src/views/New.vue
@@ -12,11 +12,6 @@
       <template v-slot:top>
         <v-toolbar flat color="white">
           <v-toolbar-title>My Life Graph</v-toolbar-title>
-          <v-divider
-            class="mx-4"
-            inset
-            vertical
-          />
           <v-spacer />
           <!-- v-dialogでモーダル表示部分の設定 -->
           <v-dialog v-model="dialog" max-width="500px">
@@ -56,12 +51,12 @@
                         label="コメント"
                       />
                     </v-col>
-                    <v-col cols="12" sm="6" md="4">
+                    <!-- <v-col cols="12" sm="6" md="4">
                       <v-text-field
                         v-model="editedItem.title"
                         label="タイトル"
                       />
-                    </v-col>
+                    </v-col> -->
                   </v-row>
                 </v-container>
               </v-card-text>
@@ -100,6 +95,64 @@
         </v-icon>
       </template>
     </v-data-table>
+    <!-- <v-data-table
+      :headers="titleHeader"
+      :items="title"
+      class="elevation-2"
+    >
+      <v-toolbar flat color="white">
+        <v-spacer />
+        <v-dialog v-model="titleDialog" max-width="500px">
+          <template v-slot:activator="{ on }">
+            <v-btn
+              class="white-text"
+              large
+              color="#64D8CB"
+              v-on="on"
+            >
+              タイトルを編集する
+            </v-btn>
+          </template>
+          <v-card>
+            <v-card-title>
+              <span>タイトルを編集する</span>
+            </v-card-title>
+            <v-card-text>
+              <v-container>
+                <v-row>
+                  <v-col cols="12">
+                    <v-text-filed
+                      v-model="editedTitle"
+                      label="タイトル"
+                    />
+                  </v-col>
+                </v-row>
+              </v-container>
+            </v-card-text>
+            <v-card-actions>
+              <v-spacer />
+              <v-btn
+                color="teal"
+                text @click="close"
+              >
+                キャンセル
+              </v-btn>
+              <v-btn
+                color="teal"
+                text @click="save"
+              >
+                登録する
+              </v-btn>
+            </v-card-actions>
+          </v-card>
+        </v-dialog>
+      </v-toolbar>
+    </v-data-table> -->
+    <v-btn
+      @click="createChart"
+    >
+      確定
+    </v-btn>
   </v-container>
 </template>
 
@@ -116,7 +169,6 @@ export default {
       },
       { text: 'スコア', value: 'score' },
       { text: 'コメント', value: 'comment' },
-      { text: 'タイトル', value: 'title' },
       { text: '編集', value: 'actions', sortable: false }
     ],
     // chartSets部分にage,score,title,commentの配列を渡す
@@ -130,19 +182,26 @@ export default {
       //   title: 'タイトル'
       // }
     ],
+    // titleHeader: {
+    //   text: 'タイトル',
+    //   value: 'title'
+    // },
+    // title: '',
     editedIndex: -1,
     editedItem: {
       age: 0,
       score: 0,
-      comment: '',
-      title: ''
+      comment: ''
     },
+    // editedTitle: {
+    //   title: ''
+    // },
     defaultItem: {
       age: 0,
       score: 0,
-      comment: '',
-      title: ''
-    }
+      comment: ''
+    },
+    defaultTitle: 'コメントが入ります'
   }),
   computed: {
     // モーダル表示タイトルを条件分岐で変更。インデックス数値が-1だった場合追加する、1以上の場合（すでに登録されている)編集すると表示される
@@ -154,22 +213,21 @@ export default {
     dialog (val) {
       val || this.close()
     }
+    // titleDialog (val) {
+    //   val || this.titleClose()
+    // }
   },
   methods: {
     // モーダルのフォームデフォルトに登録済みのデータを表示
     editItem (item) {
       this.editedIndex = this.chartSets.indexOf(item)
       this.editedItem = Object.assign({}, item)
-      // storeのデータを書き込むdispatchでstoreのアクションを呼び込む
-      // const editedItems = this.editedItem
-      // this.$store.dispatch('chart/edit,editedItems)
       this.dialog = true
-      // storeのデータを書き込むdispatchでstoreのアクションを呼び込む
     },
     // index番号と一致するレコードの削除
     deleteItem (item) {
       const index = this.chartSets.indexOf(item)
-      confirm('本当に削除しますか？') && this.desserts.splice(index, 1)
+      confirm('本当に削除しますか？') && this.chartSets.splice(index, 1)
     },
     // モーダルを閉じ,
     close () {
@@ -189,6 +247,21 @@ export default {
         this.chartSets.push(this.editedItem)
       }
       this.close()
+    },
+    // editTitle (title) {
+    //   this.editedTitle = Object.assign({}, title)
+    //   this.titleDialog = true
+    // },
+    // titleClose () {
+    //   this.titleDialog = false
+    //   this.editedTitle = Object.assign({}, this.defaultTitle)
+    //   // indexを-1にする処理はいらないと思う
+    // },
+    createChart () {
+      // メソッド内でconst定義している場合、thisは不要
+      // setContentsをdispatchして、lifeChartを渡す。
+      this.$store.dispatch('setContents', this.chartSets)
+      this.$router.push('/top')
     }
   }
 }


### PR DESCRIPTION
# レビュー観点
chart.jsにStore領域を作成し、登録画面で入力されたデータが
Storeで管理され、グラフのコンポーネント部分で呼び込めるようにしました。

登録画面側は、一旦データテーブルに入力した値を、確定ボタンでまとめてStoreで管理させるようにしています。現時点で登録編集画面のモックアップ作成のタスクは完了しておりますが、vee-validateの実装を
できていないことに気づいたので、追加で実装する予定です。

# 変更内容／作業内容
 - [ ] データの状態管理を行うchart.jsの実装
 - [ ] chart.vueの修正(Storeからデータの取得とtooltipの追加)
 - [ ] 登録画面の修正(Storeにデータを持たせる)
