### PR TITLE
ログイン画面のつなぎこみ

### DIFF
--- a/vue/package-lock.json
+++ b/vue/package-lock.json
@@ -10483,7 +10483,7 @@
     },
     "sass": {
       "version": "1.26.5",
-      "resolved": "https://registry.npm.taobao.org/sass/download/sass-1.26.5.tgz",
+      "resolved": "https://registry.npm.taobao.org/sass/download/sass-1.26.5.tgz?cache=0&sync_timestamp=1587697502481&other_urls=https%3A%2F%2Fregistry.npm.taobao.org%2Fsass%2Fdownload%2Fsass-1.26.5.tgz",
       "integrity": "sha1-LXrs+7q/ophWfI8GYVtuJNLWgJk=",
       "dev": true,
       "requires": {

--- a/vue/src/router/index.js
+++ b/vue/src/router/index.js
@@ -1,6 +1,7 @@
 import Vue from 'vue'
 import VueRouter from 'vue-router'
-// import { Store } from 'vuex'
+// 未ログイン状態の時にログイン画面に飛ばす設定
+// import Store from '@/store/index.js'
 
 Vue.use(VueRouter)
 
@@ -10,6 +11,9 @@ const routes = [
     name: 'Login', // new add
     component: function () {
       return import(/* webpackChunkName: "about" */ '../views/Login.vue')
+    },
+    meta: {
+      isPublic: true
     }
   },
   {
@@ -17,6 +21,9 @@ const routes = [
     name: 'SignUp', // new add
     component: function () {
       return import(/* webpackChunkName: "about" */ '../views/SignUp.vue')
+    },
+    meta: {
+      isPublic: true
     }
   },
   {
@@ -67,12 +74,14 @@ const router = new VueRouter({
   routes
 })
 
-// login画面ではないかつtokenを持っていない場合はlogin画面に飛ぶ
-// router.beforeEach((to, form, next) => {
-//   if (to.path !== '/login' && Store.state.auth.token === '') {
-//     next('./login')
-//   } else {
+// 未ログイン状態の時にログイン画面に飛ばす設定
+// router.beforeEach((to, from, next) => {
+//   // ログイン画面以外の画面かつ未ログインの時
+//   if (to.matched.some(page => page.meta.isPublic) || Store.state.account.token) {
 //     next()
+//   } else {
+//     next('/')
 //   }
 // })
+
 export default router

--- a/vue/src/views/Login.vue
+++ b/vue/src/views/Login.vue
@@ -14,19 +14,20 @@
         <v-form
           ref="form"
         >
-          <v-text-field v-model="username" type="username" prepend-icon="mdi-gmail" label="ユーザーネーム" :rules="[required]" />
+          <v-text-field v-model="username" type="username" prepend-icon="mdi-gmail" label="ユーザーネーム" :rules="[required]" color="teal" />
           <!-- mdi-eye-offの部分は時間がなければなくします -->
-          <v-text-field v-model="password" type="password" prepend-icon="mdi-lock" append-icon="mdi-eye-off" label="パスワード" :rules="[required]" />
+          <v-text-field v-model="password" :type="show ? 'text' : 'password'" :append-icon="show ? 'mdi-eye' : 'mdi-eye-off'" prepend-icon="mdi-lock" label="パスワード" :rules="[required]" color="teal" @click:append="show = !show" />
           <v-card-actions>
             <v-btn outlined large color="#26A69A" to="/signup">
-              新規登録
+              新規登録はこちら
             </v-btn>
             <v-spacer />
             <v-btn large color="#26A69A" class="log-btn" @click="login()">
-              ログイン
+              ログインする
             </v-btn>
           </v-card-actions>
         </v-form>
+        <p>*登録済みの方はユーザーネームとパスワードを入力するとログインができます</p>
       </v-card-text>
     </v-card>
   </div>
@@ -44,7 +45,8 @@ export default {
     //   return pattern.test(value) || 'メールアドレスの形式が正しくありません'
     // },
     password: '',
-    required: value => !!value || '必ず入力してください'
+    required: value => !!value || '必ず入力してください',
+    show: false
   }),
   // token関数でtokenの値を取得する
   computed: {

--- a/vue/src/views/SignUp.vue
+++ b/vue/src/views/SignUp.vue
@@ -56,12 +56,6 @@ export default {
           email: this.email,
           password: this.password
         })
-          .then(function (res) {
-            console.log(res)
-          })
-          .catch(function (error) {
-            console.log(error)
-          })
         this.$router.push('/')
       }
     }

--- a/vue/src/views/SignUp.vue
+++ b/vue/src/views/SignUp.vue
@@ -11,14 +11,16 @@
         </h1>
       </v-card-title>
       <v-card-text>
-        <v-form>
-          <v-text-field type="userName" prepend-icon="mdi-account-circle" label="アカウント名" />
-          <v-text-field type="mail" prepend-icon="mdi-gmail" label="メールアドレス" />
+        <v-form
+          ref="form"
+        >
+          <v-text-field v-model="username" prepend-icon="mdi-account-circle" label="アカウント名" :rules="[required]" color="teal" />
+          <v-text-field v-model="email" prepend-icon="mdi-gmail" label="メールアドレス" :rules="[required, emailRules]" color="teal" />
           <!-- mdi-eye-offの部分はブラッシュアップにまわす -->
-          <v-text-field type="password" prepend-icon="mdi-lock" append-icon="mdi-eye-off" label="パスワード" />
+          <v-text-field v-model="password" :type="show ? 'text' : 'password'" :append-icon="show ? 'mdi-eye' : 'mdi-eye-off'" prepend-icon="mdi-lock" label="パスワード" :rules="[required, max_length]" color="teal" @click:append="show = !show" />
           <v-card-actions>
-            <v-btn large color="#26A69A" class="signup-btn" to="/top">
-              新規登録
+            <v-btn large color="#26A69A" class="signup-btn" @click="signup()">
+              新規登録をする
             </v-btn>
           </v-card-actions>
         </v-form>
@@ -27,11 +29,44 @@
   </div>
 </template>
 
-<style scoped>
-</style>
-
 <script>
-//
+import axios from 'axios'
+
+export default {
+  data: () => ({
+    username: '',
+    email: '',
+    // メアドのバリデーション規則
+    emailRules: value => {
+      const pattern = /^(([^<>()[\]\\.,;:\s@]+(\.[^<>()[\]\\.,;:\s@]+)*)|(.+))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/
+      return pattern.test(value) || 'メールアドレスの形式が正しくありません'
+    },
+    password: '',
+    max_length: value => value.length >= 8 || '8文字以上で入力してください',
+    // 基本バリデーション
+    required: value => !!value || '必ず入力してください',
+    show: false
+  }),
+  methods: {
+    signup () {
+      if (this.$refs.form.validate()) {
+        const url = '/api/auth/signup'
+        axios.post(url, {
+          username: this.username,
+          email: this.email,
+          password: this.password
+        })
+          .then(function (res) {
+            console.log(res)
+          })
+          .catch(function (error) {
+            console.log(error)
+          })
+        this.$router.push('/')
+      }
+    }
+  }
+}
 </script>
 <style>
 .logo{


### PR DESCRIPTION
# レビュー観点
ログイン画面のつなぎこみですが、ログインAPIとの兼ね合いで現状ユーザーネームとパスワードを入力するとログインできる状態です。明日、ユーザーネーム部分をメールアドレスに変更します。

未ログイン状態で新規登録画面とログイン画面以外に遷移した場合にログイン画面に遷移させるようにしました。


# 変更内容／作業内容
 - [ ] 未ログイン状態の遷移設定(index.js)
 - [ ] 新規登録時のデータの組み込み(Signup.vue)
 - [ ] ログインAPIとのつなぎこみ(Login.vue)
 - [ ] フォームのオプションを追加(password入力時に可視、不可視の切り替え)
